### PR TITLE
Centralize common dependencies in `[workspace.dependencies]`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,12 @@ repository = "https://github.com/jwodder/rswodlib"
 license = "MIT"
 
 [workspace.dependencies]
+futures-util = { version = "0.3.29", default-features = false }
+pin-project-lite = "0.2.12"
+rstest = { version = "0.24.0", default-features = false }
+thiserror = "2.0.0"
 tokio = "1.37.0"
+tokio-util =  "0.7.10"
 
 [package]
 name = "rswodlib"
@@ -23,7 +28,7 @@ license.workspace = true
 automod = "1.0.8"
 
 [dev-dependencies]
-rstest = { version = "0.24.0", default-features = false }
+rstest.workspace = true
 
 [lints]
 workspace = true

--- a/crates/generic-num/Cargo.toml
+++ b/crates/generic-num/Cargo.toml
@@ -10,7 +10,7 @@ license.workspace = true
 num-traits = "0.2.15"
 
 [dev-dependencies]
-rstest = { version = "0.24.0", default-features = false }
+rstest.workspace = true
 
 [lints]
 workspace = true

--- a/crates/loggedcmd/Cargo.toml
+++ b/crates/loggedcmd/Cargo.toml
@@ -9,7 +9,7 @@ license.workspace = true
 [dependencies]
 log = "0.4.20"
 shell-words = "1.1.0"
-thiserror = "2.0.0"
+thiserror.workspace = true
 
 [lints]
 workspace = true

--- a/crates/runcmd/Cargo.toml
+++ b/crates/runcmd/Cargo.toml
@@ -9,7 +9,7 @@ license.workspace = true
 [dependencies]
 bstr = { version = "1.4.0", default-features = false, features = ["std"] }
 rswodlib = { path = "../.." }
-thiserror = "2.0.0"
+thiserror.workspace = true
 
 [dev-dependencies]
 assert_fs = "1.0.13"

--- a/crates/tokio-btn/Cargo.toml
+++ b/crates/tokio-btn/Cargo.toml
@@ -7,9 +7,9 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-futures-util = { version = "0.3.29", default-features = false, features = ["std"] }
+futures-util = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["sync"] }
-tokio-util = { version = "0.7.10", features = ["rt"] }
+tokio-util = { workspace = true, features = ["rt"] }
 
 [lints]
 workspace = true

--- a/crates/tokio-buffered-tasks/Cargo.toml
+++ b/crates/tokio-buffered-tasks/Cargo.toml
@@ -7,7 +7,7 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-futures-util = { version = "0.3.29", default-features = false, features = ["std"] }
+futures-util = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["rt", "sync"] }
 
 [lints]

--- a/crates/tokio-buffered-tasks/Cargo.toml
+++ b/crates/tokio-buffered-tasks/Cargo.toml
@@ -7,7 +7,7 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-futures-util = { workspace = true, features = ["std"] }
+futures-util.workspace = true
 tokio = { workspace = true, features = ["rt", "sync"] }
 
 [lints]

--- a/crates/tokio-lsg/Cargo.toml
+++ b/crates/tokio-lsg/Cargo.toml
@@ -7,9 +7,9 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-futures-util = { version = "0.3.29", default-features = false, features = ["std"] }
+futures-util = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["sync"] }
-tokio-util = { version = "0.7.10", features = ["rt"] }
+tokio-util = { workspace = true, features = ["rt"] }
 
 [lints]
 workspace = true

--- a/crates/tokio-lsg/Cargo.toml
+++ b/crates/tokio-lsg/Cargo.toml
@@ -7,7 +7,7 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-futures-util = { workspace = true, features = ["std"] }
+futures-util.workspace = true
 tokio = { workspace = true, features = ["sync"] }
 tokio-util = { workspace = true, features = ["rt"] }
 

--- a/crates/tokio-nursery/Cargo.toml
+++ b/crates/tokio-nursery/Cargo.toml
@@ -7,8 +7,8 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-futures-util = { version = "0.3.29", default-features = false, features = ["std"] }
-pin-project-lite = "0.2.12"
+futures-util = { workspace = true, features = ["std"] }
+pin-project-lite.workspace = true
 tokio = { workspace = true, features = ["rt", "sync"] }
 
 [dev-dependencies]

--- a/crates/tokio-received-stream/Cargo.toml
+++ b/crates/tokio-received-stream/Cargo.toml
@@ -7,8 +7,8 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-futures-util = { version = "0.3.29", default-features = false, features = ["std"] }
-pin-project-lite = "0.2.12"
+futures-util = { workspace = true, features = ["std"] }
+pin-project-lite.workspace = true
 tokio = { workspace = true, features = ["sync"] }
 
 [dev-dependencies]

--- a/crates/tokio-received-stream/Cargo.toml
+++ b/crates/tokio-received-stream/Cargo.toml
@@ -7,7 +7,7 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-futures-util = { workspace = true, features = ["std"] }
+futures-util.workspace = true
 pin-project-lite.workspace = true
 tokio = { workspace = true, features = ["sync"] }
 

--- a/crates/tokio-shutdown-group/Cargo.toml
+++ b/crates/tokio-shutdown-group/Cargo.toml
@@ -8,10 +8,10 @@ license.workspace = true
 
 [dependencies]
 tokio = { workspace = true, features = ["time"] }
-tokio-util = { version = "0.7.10", features = ["rt"] }
+tokio-util = { workspace = true, features = ["rt"] }
 
 [dev-dependencies]
-futures-util = { version = "0.3.29", default-features = false, features = ["std"] }
+futures-util = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["macros", "rt"] }
 
 [lints]

--- a/crates/tokio-shutdown-group/Cargo.toml
+++ b/crates/tokio-shutdown-group/Cargo.toml
@@ -11,7 +11,6 @@ tokio = { workspace = true, features = ["time"] }
 tokio-util = { workspace = true, features = ["rt"] }
 
 [dev-dependencies]
-futures-util = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["macros", "rt"] }
 
 [lints]

--- a/crates/tokio-shutdown-group/src/lib.rs
+++ b/crates/tokio-shutdown-group/src/lib.rs
@@ -54,7 +54,7 @@ mod tests {
         group.spawn(|token| async move {
             tokio::select! {
                 () = token.cancelled() => (),
-                () = futures_util::future::ready(()) => my_finished.store(true, Ordering::Release),
+                () = std::future::ready(()) => my_finished.store(true, Ordering::Release),
             }
         });
         let task2_cancelled = Arc::new(AtomicBool::new(false));

--- a/crates/tokio-worker-map/Cargo.toml
+++ b/crates/tokio-worker-map/Cargo.toml
@@ -8,8 +8,8 @@ license.workspace = true
 
 [dependencies]
 async-channel = "2.3.1"
-futures-util = { version = "0.3.29", default-features = false, features = ["std"] }
-pin-project-lite = "0.2.12"
+futures-util = { workspace = true, features = ["std"] }
+pin-project-lite.workspace = true
 tokio = { workspace = true, features = ["rt", "sync"] }
 
 [dev-dependencies]

--- a/crates/unique-stream/Cargo.toml
+++ b/crates/unique-stream/Cargo.toml
@@ -7,7 +7,7 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-futures-util = { workspace = true, features = ["std"] }
+futures-util.workspace = true
 pin-project-lite.workspace = true
 
 [dev-dependencies]

--- a/crates/unique-stream/Cargo.toml
+++ b/crates/unique-stream/Cargo.toml
@@ -7,8 +7,8 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-futures-util = { version = "0.3.29", default-features = false, features = ["std"] }
-pin-project-lite = "0.2.12"
+futures-util = { workspace = true, features = ["std"] }
+pin-project-lite.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt"] }


### PR DESCRIPTION
Closes #39.