### PR TITLE
`show_duration.rs`: Convert to an extension trait

### DIFF
--- a/src/show_duration.rs
+++ b/src/show_duration.rs
@@ -1,28 +1,35 @@
 use std::fmt::{self, Write};
 use std::time::Duration;
 
-/// Returns a structure that displays the given [`Duration`] as a
-/// floating-point number of seconds using no more precision than is necessary.
-///
-/// # Example
-///
-/// ```
-/// # use rswodlib::show_duration::show_duration_as_seconds;
-/// # use std::time::Duration;
-/// let d1 = Duration::from_secs(42);
-/// assert_eq!(show_duration_as_seconds(d1).to_string(), "42");
-///
-/// let d2 = Duration::from_nanos(123_000_000);
-/// assert_eq!(show_duration_as_seconds(d2).to_string(), "0.123");
-/// ```
-pub fn show_duration_as_seconds(d: Duration) -> ShowDurationAsSeconds {
-    ShowDurationAsSeconds(d)
+pub trait DurationExt {
+    /// Returns a structure that displays the given [`Duration`] as a
+    /// floating-point number of seconds using no more precision than is
+    /// necessary.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use rswodlib::show_duration::DurationExt;
+    /// # use std::time::Duration;
+    /// let d1 = Duration::from_secs(42);
+    /// assert_eq!(d1.display_as_seconds().to_string(), "42");
+    ///
+    /// let d2 = Duration::from_nanos(123_000_000);
+    /// assert_eq!(d2.display_as_seconds().to_string(), "0.123");
+    /// ```
+    fn display_as_seconds(self) -> DisplayAsSeconds;
+}
+
+impl DurationExt for Duration {
+    fn display_as_seconds(self) -> DisplayAsSeconds {
+        DisplayAsSeconds(self)
+    }
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub struct ShowDurationAsSeconds(Duration);
+pub struct DisplayAsSeconds(Duration);
 
-impl fmt::Display for ShowDurationAsSeconds {
+impl fmt::Display for DisplayAsSeconds {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0.as_secs())?;
         let nanos = self.0.subsec_nanos();
@@ -55,6 +62,6 @@ mod tests {
     #[case(10, 123456789, "10.123456789")]
     fn test(#[case] secs: u64, #[case] nanos: u32, #[case] s: &str) {
         let d = Duration::new(secs, nanos);
-        assert_eq!(show_duration_as_seconds(d).to_string(), s);
+        assert_eq!(d.display_as_seconds().to_string(), s);
     }
 }


### PR DESCRIPTION
Closes #60.